### PR TITLE
Add comprehensive configuration and translation modules

### DIFF
--- a/config/emotion_mappings.py
+++ b/config/emotion_mappings.py
@@ -1,10 +1,118 @@
-"""Mappings for Ekman emotions and synonyms."""
+"""
+Emotionen-Mappings und Synonyme für Ekman-Emotionen
+"""
 
+# Ekman-Emotionen mit Synonymen
 EKMAN_EMOTIONS = {
-    "anger": ["rage", "annoyance"],
-    "disgust": ["revulsion", "contempt"],
-    "fear": ["terror", "apprehension"],
-    "joy": ["happiness", "delight"],
-    "sadness": ["grief", "sorrow"],
-    "surprise": ["amazement", "astonishment"],
+    "joy": {
+        "name": "Freude",
+        "name_en": "Joy",
+        "synonyms": [
+            "happiness", "delight", "pleasure", "bliss", "cheerfulness",
+            "contentment", "satisfaction", "elation", "euphoria", "glee",
+            "jubilation", "mirth", "amusement", "enjoyment", "gladness"
+        ]
+    },
+    "surprise": {
+        "name": "Überraschung",
+        "name_en": "Surprise",
+        "synonyms": [
+            "astonishment", "amazement", "wonder", "bewilderment", "shock",
+            "stupefaction", "perplexity", "confusion", "disbelief", "awe"
+        ]
+    },
+    "fear": {
+        "name": "Angst",
+        "name_en": "Fear",
+        "synonyms": [
+            "anxiety", "terror", "panic", "fright", "dread", "horror",
+            "apprehension", "nervousness", "worry", "concern", "alarm",
+            "trepidation", "unease", "phobia", "scared"
+        ]
+    },
+    "anger": {
+        "name": "Wut",
+        "name_en": "Anger",
+        "synonyms": [
+            "rage", "fury", "wrath", "ire", "annoyance", "irritation",
+            "frustration", "indignation", "hostility", "resentment",
+            "outrage", "exasperation", "vexation", "mad", "furious"
+        ]
+    },
+    "disgust": {
+        "name": "Ekel",
+        "name_en": "Disgust",
+        "synonyms": [
+            "revulsion", "repulsion", "nausea", "loathing", "abhorrence",
+            "aversion", "distaste", "repugnance", "contempt", "disdain",
+            "revulsion", "sickening", "disgusting", "revolting"
+        ]
+    },
+    "sadness": {
+        "name": "Trauer",
+        "name_en": "Sadness",
+        "synonyms": [
+            "sorrow", "grief", "melancholy", "depression", "despair",
+            "dejection", "despondency", "gloom", "misery", "unhappiness",
+            "heartbreak", "anguish", "woe", "mourning", "regret"
+        ]
+    },
+    "contempt": {
+        "name": "Verachtung",
+        "name_en": "Contempt",
+        "synonyms": [
+            "scorn", "disdain", "derision", "condescension", "arrogance",
+            "superiority", "dismissal", "mockery", "ridicule", "sneering"
+        ]
+    }
 }
+
+# Valence-Kategorien mit Synonymen
+VALENCE_CATEGORIES = {
+    "positive": {
+        "name": "Positiv",
+        "name_en": "Positive",
+        "synonyms": [
+            "good", "great", "excellent", "wonderful", "fantastic",
+            "amazing", "awesome", "brilliant", "outstanding", "superb",
+            "marvelous", "terrific", "fabulous", "splendid", "magnificent"
+        ]
+    },
+    "negative": {
+        "name": "Negativ", 
+        "name_en": "Negative",
+        "synonyms": [
+            "bad", "terrible", "awful", "horrible", "dreadful",
+            "disgusting", "appalling", "atrocious", "abysmal", "deplorable",
+            "ghastly", "hideous", "revolting", "repulsive", "vile"
+        ]
+    },
+    "neutral": {
+        "name": "Neutral",
+        "name_en": "Neutral",
+        "synonyms": [
+            "okay", "alright", "fine", "acceptable", "adequate",
+            "average", "moderate", "fair", "reasonable", "standard"
+        ]
+    }
+}
+
+
+def get_all_emotion_terms(emotion_key: str) -> list:
+    """Gibt alle Begriffe (Hauptemotion + Synonyme) für eine Emotion zurück"""
+    if emotion_key in EKMAN_EMOTIONS:
+        return [emotion_key] + EKMAN_EMOTIONS[emotion_key]["synonyms"]
+    elif emotion_key in VALENCE_CATEGORIES:
+        return [emotion_key] + VALENCE_CATEGORIES[emotion_key]["synonyms"]
+    else:
+        return [emotion_key]
+
+
+def get_emotion_display_name(emotion_key: str, language: str = "DE") -> str:
+    """Gibt den Anzeigenamen für eine Emotion zurück"""
+    if emotion_key in EKMAN_EMOTIONS:
+        return EKMAN_EMOTIONS[emotion_key]["name" if language == "DE" else "name_en"]
+    elif emotion_key in VALENCE_CATEGORIES:
+        return VALENCE_CATEGORIES[emotion_key]["name" if language == "DE" else "name_en"]
+    else:
+        return emotion_key.title()

--- a/config/languages.py
+++ b/config/languages.py
@@ -1,12 +1,148 @@
-"""Language utilities."""
+"""
+Mehrsprachige Texte für die Benutzeroberfläche
+"""
 
-LANG_STRINGS = {
-    "en": {
-        "title": "Sentiment Analysis Toolkit",
-        "input_label": "Enter text",
+TRANSLATIONS = {
+    "DE": {
+        # Navigation
+        "title": "🧠 Sentiment Analysis Toolkit",
+        "subtitle": "Professionelle Sentiment- und Emotionsanalyse",
+
+        # Sidebar
+        "analysis_type": "Analyse-Typ",
+        "model_selection": "Modell-Auswahl",
+        "benchmark_mode": "Benchmark-Modus",
+        "benchmark_description": "Vergleicht alle verfügbaren Modelle",
+        "single_model": "Einzelnes Modell",
+        "language_settings": "Sprach-Einstellungen",
+
+        # Input
+        "input_method": "Eingabe-Methode",
+        "single_text": "Einzelner Text",
+        "batch_upload": "Batch-Upload",
+        "text_input": "Text eingeben",
+        "text_placeholder": "Geben Sie hier Ihren Text ein...",
+        "file_upload": "Datei hochladen",
+        "file_types": "Unterstützte Formate: CSV, TXT",
+
+        # Analysis
+        "analyze_button": "Analysieren",
+        "analyzing": "Analysiere...",
+        "analysis_complete": "Analyse abgeschlossen",
+        "text_count": "Anzahl Texte",
+        "processing_time": "Verarbeitungszeit",
+
+        # Results
+        "results": "Ergebnisse",
+        "valence_results": "Valence-Ergebnisse",
+        "ekman_results": "Ekman-Emotionen",
+        "emotion_arc_results": "Emotion Arc",
+        "benchmark_results": "Benchmark-Ergebnisse",
+
+        # Export
+        "export": "Export",
+        "export_csv": "Als CSV exportieren",
+        "export_excel": "Als Excel exportieren",
+        "download": "Herunterladen",
+
+        # Emotions
+        "positive": "Positiv",
+        "negative": "Negativ",
+        "neutral": "Neutral",
+        "joy": "Freude",
+        "surprise": "Überraschung",
+        "fear": "Angst",
+        "anger": "Wut",
+        "disgust": "Ekel",
+        "sadness": "Trauer",
+        "contempt": "Verachtung",
+
+        # Errors
+        "error_no_text": "Bitte geben Sie einen Text ein.",
+        "error_no_file": "Bitte laden Sie eine Datei hoch.",
+        "error_api_key": "API-Schlüssel fehlt oder ungültig.",
+        "error_processing": "Fehler bei der Verarbeitung.",
+        "error_file_format": "Ungültiges Dateiformat.",
+
+        # Arc Analysis
+        "arc_pattern": "Erkanntes Muster",
+        "arc_confidence": "Konfidenz",
+        "arc_features": "Arc-Eigenschaften",
+        "key_moments": "Schlüsselmomente",
+        "story_progression": "Handlungsverlauf"
     },
-    "de": {
-        "title": "Sentiment-Analyse Toolkit",
-        "input_label": "Text eingeben",
-    },
+
+    "EN": {
+        # Navigation
+        "title": "🧠 Sentiment Analysis Toolkit",
+        "subtitle": "Professional Sentiment and Emotion Analysis",
+
+        # Sidebar
+        "analysis_type": "Analysis Type",
+        "model_selection": "Model Selection",
+        "benchmark_mode": "Benchmark Mode",
+        "benchmark_description": "Compares all available models",
+        "single_model": "Single Model",
+        "language_settings": "Language Settings",
+
+        # Input
+        "input_method": "Input Method",
+        "single_text": "Single Text",
+        "batch_upload": "Batch Upload",
+        "text_input": "Enter Text",
+        "text_placeholder": "Enter your text here...",
+        "file_upload": "Upload File",
+        "file_types": "Supported formats: CSV, TXT",
+
+        # Analysis
+        "analyze_button": "Analyze",
+        "analyzing": "Analyzing...",
+        "analysis_complete": "Analysis Complete",
+        "text_count": "Number of Texts",
+        "processing_time": "Processing Time",
+
+        # Results
+        "results": "Results",
+        "valence_results": "Valence Results",
+        "ekman_results": "Ekman Emotions",
+        "emotion_arc_results": "Emotion Arc",
+        "benchmark_results": "Benchmark Results",
+
+        # Export
+        "export": "Export",
+        "export_csv": "Export as CSV",
+        "export_excel": "Export as Excel",
+        "download": "Download",
+
+        # Emotions
+        "positive": "Positive",
+        "negative": "Negative",
+        "neutral": "Neutral",
+        "joy": "Joy",
+        "surprise": "Surprise",
+        "fear": "Fear",
+        "anger": "Anger",
+        "disgust": "Disgust",
+        "sadness": "Sadness",
+        "contempt": "Contempt",
+
+        # Errors
+        "error_no_text": "Please enter a text.",
+        "error_no_file": "Please upload a file.",
+        "error_api_key": "API key missing or invalid.",
+        "error_processing": "Error during processing.",
+        "error_file_format": "Invalid file format.",
+
+        # Arc Analysis
+        "arc_pattern": "Detected Pattern",
+        "arc_confidence": "Confidence",
+        "arc_features": "Arc Features",
+        "key_moments": "Key Moments",
+        "story_progression": "Story Progression"
+    }
 }
+
+
+def get_text(key: str, language: str = "DE") -> str:
+    """Holt übersetzten Text"""
+    return TRANSLATIONS.get(language, {}).get(key, key)

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,18 +1,134 @@
-"""Application settings."""
+"""
+Zentrale Konfiguration für das Sentiment Analysis Toolkit
+"""
 
+import os
 from dataclasses import dataclass
+from typing import Dict, List, Optional
+import streamlit as st
 
 
 @dataclass
+class ModelConfig:
+    """Konfiguration für einzelne Modelle"""
+    name: str
+    display_name: str
+    api_type: str
+    supports_valence: bool = True
+    supports_ekman: bool = True
+    supports_emotion_arc: bool = True
+    max_tokens: int = 4000
+    rate_limit: int = 60  # Requests per minute
+
+
+@dataclass
+class APIConfig:
+    """API Konfiguration"""
+    primary_key: str
+    fallback_key: Optional[str] = None
+    base_url: Optional[str] = None
+    timeout: int = 30
+
+
 class Settings:
-    """Basic configuration for the app."""
+    """Zentrale Einstellungen"""
 
-    app_name: str = "Sentiment Analysis Toolkit"
-    version: str = "0.1.0"
-    supported_languages: tuple[str, ...] = ("en", "de")
+    # Verfügbare Modelle
+    MODELS = {
+        "apt-5-nano": ModelConfig(
+            name="apt-5-nano",
+            display_name="OpenAI GPT-5 Nano",
+            api_type="openai_reasoning",
+            max_tokens=8000,
+            rate_limit=100
+        ),
+        "deepseek-chat": ModelConfig(
+            name="deepseek-chat",
+            display_name="DeepSeek Chat",
+            api_type="deepseek",
+            max_tokens=4000,
+            rate_limit=60
+        ),
+        "facebook/bart-large": ModelConfig(
+            name="facebook/bart-large",
+            display_name="BART Large (HuggingFace)",
+            api_type="huggingface",
+            supports_emotion_arc=False,
+            max_tokens=1024,
+            rate_limit=100
+        ),
+        "FacebookAI/roberta-base": ModelConfig(
+            name="FacebookAI/roberta-base",
+            display_name="RoBERTa Base (HuggingFace)",
+            api_type="huggingface",
+            supports_emotion_arc=False,
+            max_tokens=512,
+            rate_limit=100
+        ),
+        "siebert/sentiment-roberta-large-english": ModelConfig(
+            name="siebert/sentiment-roberta-large-english",
+            display_name="SiEBERT (HuggingFace)",
+            api_type="huggingface",
+            supports_ekman=False,
+            supports_emotion_arc=False,
+            max_tokens=512,
+            rate_limit=100
+        ),
+        "vader": ModelConfig(
+            name="vader",
+            display_name="VADER",
+            api_type="vader",
+            supports_ekman=False,
+            supports_emotion_arc=False,
+            max_tokens=10000,
+            rate_limit=1000
+        )
+    }
 
+    # API Konfigurationen
+    @staticmethod
+    def get_api_config(api_type: str) -> APIConfig:
+        """Holt API-Konfiguration aus Streamlit Secrets"""
+        if api_type == "openai_reasoning":
+            return APIConfig(
+                primary_key=st.secrets.get("OPENAI_API_KEY_01", ""),
+                fallback_key=st.secrets.get("OPENAI_API_KEY_02", ""),
+                base_url="https://api.openai.com/v1"
+            )
+        elif api_type == "deepseek":
+            return APIConfig(
+                primary_key=st.secrets.get("DEEPSEEK_API_KEY_01", ""),
+                fallback_key=st.secrets.get("DEEPSEEK_API_KEY_02", ""),
+                base_url="https://api.deepseek.com"
+            )
+        elif api_type == "huggingface":
+            return APIConfig(
+                primary_key=st.secrets.get("HUGGING_FACE_API_KEY", ""),
+                fallback_key=st.secrets.get("HUGGING_FACE_API_KEY_02", ""),
+                base_url="https://api-inference.huggingface.co"
+            )
+        else:
+            return APIConfig(primary_key="")
 
-def get_settings() -> Settings:
-    """Return application settings."""
+    # Analyse-Typen
+    ANALYSIS_TYPES = {
+        "valence": "Valence (Positiv/Negativ/Neutral)",
+        "ekman": "Ekman-Emotionen",
+        "emotion_arc": "Emotion Arc"
+    }
 
-    return Settings()
+    # Batch-Verarbeitung
+    MAX_BATCH_SIZE = 100
+    DEFAULT_BATCH_SIZE = 20
+
+    # Export-Formate
+    EXPORT_FORMATS = ["CSV", "Excel", "JSON"]
+
+    # UI-Einstellungen
+    DEFAULT_LANGUAGE = "DE"
+    SUPPORTED_LANGUAGES = ["DE", "EN"]
+
+    # Performance
+    MAX_WORKERS = 5
+    REQUEST_TIMEOUT = 30
+    RETRY_ATTEMPTS = 3


### PR DESCRIPTION
## Summary
- replace the settings module with dataclass-driven model and API configuration along with application constants
- expand localization strings for German and English interfaces and add a translation helper
- enrich emotion mappings with detailed metadata and helper utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9153fc838832782076725ac9e0ef0