### PR TITLE
Implement full Streamlit UI and analysis workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,16 +1,159 @@
-"""Streamlit entrypoint."""
+"""Streamlit entrypoint for the Sentiment Analysis Toolkit."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
 
 import streamlit as st
 
-from ui.sidebar import render_sidebar
-from ui.main_content import render_main
+from analyzers.base_analyzer import AnalysisResult
+from config.languages import get_text
+from config.settings import Settings
+from models.ekman_analyzer import EkmanAnalyzer
+from models.emotion_arc_analyzer import EmotionArcAnalyzer
+from models.valence_analyzer import ValenceAnalyzer
+from ui.main_content import MainContentUI
+from ui.results_display import ResultsDisplayUI
+from ui.sidebar import SidebarUI
+
+
+def _get_valence_analyzer() -> ValenceAnalyzer:
+    if "valence_analyzer" not in st.session_state:
+        st.session_state["valence_analyzer"] = ValenceAnalyzer()
+    return st.session_state["valence_analyzer"]
+
+
+def _get_ekman_analyzer() -> EkmanAnalyzer:
+    if "ekman_analyzer" not in st.session_state:
+        st.session_state["ekman_analyzer"] = EkmanAnalyzer()
+    return st.session_state["ekman_analyzer"]
+
+
+def _get_emotion_arc_analyzer() -> EmotionArcAnalyzer:
+    if "emotion_arc_analyzer" not in st.session_state:
+        st.session_state["emotion_arc_analyzer"] = EmotionArcAnalyzer()
+    return st.session_state["emotion_arc_analyzer"]
+
+
+def _extract_analysis_kwargs(settings: Dict[str, Any]) -> Dict[str, Any]:
+    keys = {"reasoning_effort", "verbosity", "timeout", "batch_size"}
+    return {key: settings[key] for key in keys if key in settings}
+
+
+def _run_emotion_arc_analysis(
+    texts: List[str], settings: Dict[str, Any]
+) -> List[Dict[str, AnalysisResult]]:
+    analyzer = _get_emotion_arc_analyzer()
+    n_segments = settings.get("n_segments", 20)
+    selected_models = settings.get("selected_models", [])
+    available_models = [
+        model for model in selected_models if model in getattr(analyzer, "analyzers", {})
+    ]
+    if not available_models:
+        available_models = list(getattr(analyzer, "analyzers", {}).keys())
+    if not available_models:
+        available_models = ["vader"]
+
+    kwargs = _extract_analysis_kwargs(settings)
+    results: List[Dict[str, AnalysisResult]] = []
+
+    for text in texts:
+        text_results: Dict[str, AnalysisResult] = {}
+        for model in available_models:
+            start_time = time.time()
+            arc_data = analyzer.analyze_arc(
+                text,
+                model=model,
+                n_segments=n_segments,
+                **kwargs,
+            )
+            processing_time = time.time() - start_time
+
+            if arc_data.get("error"):
+                text_results[model] = AnalysisResult(
+                    text=text,
+                    model=model,
+                    analysis_type="emotion_arc",
+                    scores={},
+                    processing_time=processing_time,
+                    metadata=arc_data,
+                    error=arc_data.get("error"),
+                )
+                continue
+
+            happiness_scores = arc_data.get("happiness_scores", [])
+            average_happiness = (
+                sum(happiness_scores) / len(happiness_scores) if happiness_scores else 0.0
+            )
+
+            text_results[model] = AnalysisResult(
+                text=text,
+                model=model,
+                analysis_type="emotion_arc",
+                scores={"happiness": float(average_happiness)},
+                processing_time=processing_time,
+                metadata=arc_data,
+            )
+        results.append(text_results)
+
+    return results
+
+
+def _run_analysis(texts: List[str], settings: Dict[str, Any]) -> List[Dict[str, AnalysisResult]]:
+    analysis_type = settings.get("analysis_type", "valence")
+    selected_models = settings.get("selected_models", [])
+    kwargs = _extract_analysis_kwargs(settings)
+
+    if analysis_type == "valence":
+        analyzer = _get_valence_analyzer()
+        return analyzer.analyze_batch(texts, selected_models, **kwargs)
+    if analysis_type == "ekman":
+        analyzer = _get_ekman_analyzer()
+        return analyzer.analyze_batch(texts, selected_models, **kwargs)
+    if analysis_type == "emotion_arc":
+        return _run_emotion_arc_analysis(texts, settings)
+    return []
 
 
 def main() -> None:
     """Run the Streamlit app."""
+    st.set_page_config(page_title="Sentiment Analysis Toolkit", layout="wide")
 
-    render_sidebar()
-    render_main()
+    sidebar = SidebarUI()
+    settings = sidebar.render()
+    language = settings.get("language", Settings.DEFAULT_LANGUAGE)
+
+    main_content = MainContentUI(language)
+    main_content.render_header()
+    input_data = main_content.render_input_section()
+
+    should_run = main_content.render_analysis_button(input_data, settings)
+
+    if should_run and input_data.get("valid"):
+        with st.spinner(get_text_message(language)):
+            texts = input_data.get("texts", [])
+            results = _run_analysis(texts, settings)
+        st.session_state["analysis_results"] = results
+        st.session_state["analysis_metadata"] = {
+            "analysis_type": settings.get("analysis_type", "valence"),
+            "selected_models": settings.get("selected_models", []),
+            "benchmark_mode": settings.get("benchmark_mode", False),
+            **{key: value for key, value in settings.items() if key not in {"language"}},
+        }
+
+    stored_results = st.session_state.get("analysis_results", [])
+    stored_metadata = st.session_state.get("analysis_metadata", {})
+
+    if stored_results:
+        results_ui = ResultsDisplayUI(language)
+        analysis_type = stored_metadata.get("analysis_type", "valence")
+        results_ui.render_results_section(stored_results, analysis_type, stored_metadata)
+
+
+def get_text_message(language: str) -> str:
+    """Return a language specific progress message."""
+    return get_text("analyzing", language)
 
 
 if __name__ == "__main__":

--- a/config/settings.py
+++ b/config/settings.py
@@ -79,7 +79,7 @@ class Settings:
             display_name="VADER",
             api_type="vader",
             supports_ekman=False,
-            supports_emotion_arc=False,
+            supports_emotion_arc=True,
             max_tokens=10000,
             rate_limit=1000
         )

--- a/ui/main_content.py
+++ b/ui/main_content.py
@@ -1,10 +1,187 @@
-"""Main content for the Streamlit app."""
+"""Main content components for the Streamlit application."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
 
 import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
+
+from config.languages import get_text
+from utils.data_loader import DataLoader
+from utils.text_processor import TextProcessor
 
 
-def render_main() -> None:
-    """Render main content."""
+class MainContentUI:
+    """Manage the central content area of the application."""
 
-    st.title("Sentiment Analysis Toolkit")
-    st.text_area("Enter text")
+    def __init__(self, language: str = "DE") -> None:
+        self.language = language
+        self.data_loader = DataLoader()
+        self.text_processor = TextProcessor()
+
+    def render_header(self) -> None:
+        """Render the main page header."""
+        st.title(get_text("title", self.language))
+        st.markdown(get_text("subtitle", self.language))
+        st.divider()
+
+    def render_input_section(self) -> Dict[str, Any]:
+        """Render the input section and return the captured data."""
+        st.subheader("📝 " + get_text("input_method", self.language))
+
+        input_method = st.radio(
+            get_text("input_method", self.language),
+            options=["single_text", "batch_upload"],
+            format_func=lambda key: get_text(key, self.language),
+            horizontal=True,
+            key="input_method",
+        )
+
+        if input_method == "single_text":
+            return self._render_single_text_input()
+        return self._render_batch_upload()
+
+    def _render_single_text_input(self) -> Dict[str, Any]:
+        """Render a text area for analysing a single text snippet."""
+        st.markdown("#### " + get_text("text_input", self.language))
+
+        text = st.text_area(
+            get_text("text_input", self.language),
+            placeholder=get_text("text_placeholder", self.language),
+            height=200,
+            key="single_text_input",
+            label_visibility="collapsed",
+        )
+
+        if text:
+            is_valid, error_msg = self.text_processor.validate_text(text)
+            if not is_valid:
+                st.error(f"❌ {error_msg}")
+                return {"texts": [], "valid": False, "method": "single"}
+
+            cleaned_text = self.text_processor.clean_text(text)
+            st.success(f"✅ Text bereit ({len(cleaned_text)} Zeichen)")
+            return {"texts": [cleaned_text], "valid": True, "method": "single"}
+
+        return {"texts": [], "valid": False, "method": "single"}
+
+    def _render_batch_upload(self) -> Dict[str, Any]:
+        """Render the batch upload controls."""
+        st.markdown("#### " + get_text("file_upload", self.language))
+
+        uploaded_file = st.file_uploader(
+            get_text("file_upload", self.language),
+            type=["csv", "txt", "xlsx"],
+            help=get_text("file_types", self.language),
+            key="batch_file_upload",
+            label_visibility="collapsed",
+        )
+
+        if uploaded_file is None:
+            return {"texts": [], "valid": False, "method": "batch"}
+
+        with st.spinner("Datei wird verarbeitet..."):
+            texts, error = self.data_loader.load_from_file(uploaded_file)
+
+        if error:
+            st.error(f"❌ {error}")
+            return {"texts": [], "valid": False, "method": "batch"}
+
+        if not texts:
+            st.error("❌ Keine Texte in der Datei gefunden")
+            return {"texts": [], "valid": False, "method": "batch"}
+
+        valid_texts, errors = self.data_loader.validate_texts(texts)
+
+        if errors:
+            with st.expander("⚠️ Warnungen", expanded=False):
+                for warning in errors:
+                    st.warning(warning)
+
+        if not valid_texts:
+            st.error("❌ Keine gültigen Texte gefunden")
+            return {"texts": [], "valid": False, "method": "batch"}
+
+        st.success(f"✅ {len(valid_texts)} Texte erfolgreich geladen")
+
+        with st.expander("👁️ Vorschau", expanded=False):
+            preview_count = min(3, len(valid_texts))
+            for index in range(preview_count):
+                snippet = valid_texts[index][:200]
+                suffix = "..." if len(valid_texts[index]) > 200 else ""
+                st.text(f"Text {index + 1}: {snippet}{suffix}")
+            if len(valid_texts) > preview_count:
+                st.info(f"... und {len(valid_texts) - preview_count} weitere Texte")
+
+        return {"texts": valid_texts, "valid": True, "method": "batch"}
+
+    def render_analysis_button(self, input_data: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+        """Render the analyse button and return ``True`` when clicked."""
+        st.divider()
+
+        if input_data.get("valid") and input_data.get("texts"):
+            col1, col2, col3 = st.columns(3)
+
+            with col1:
+                st.metric(get_text("text_count", self.language), len(input_data["texts"]))
+
+            with col2:
+                model_count = len(settings.get("selected_models", []))
+                st.metric(get_text("model_selection", self.language), model_count)
+
+            with col3:
+                analysis_type = settings.get("analysis_type", "valence")
+                analysis_label = get_text(f"{analysis_type}_results", self.language)
+                if analysis_label == f"{analysis_type}_results":
+                    analysis_label = analysis_type.replace("_", " ").title()
+                st.metric(get_text("analysis_type", self.language), analysis_label)
+
+            button_disabled = (
+                not input_data.get("valid")
+                or not input_data.get("texts")
+                or not settings.get("selected_models")
+            )
+
+            if st.button(
+                get_text("analyze_button", self.language),
+                type="primary",
+                disabled=button_disabled,
+                use_container_width=True,
+                key="analyze_button",
+            ):
+                return True
+        else:
+            st.info("💡 " + get_text("error_no_text", self.language))
+
+        return False
+
+    def render_progress_section(self, total_tasks: int) -> Tuple[DeltaGenerator, DeltaGenerator]:
+        """Render a progress bar and return the progress related widgets."""
+        st.divider()
+        st.subheader("⚡ " + get_text("analyzing", self.language))
+
+        progress_bar = st.progress(0)
+        status_text = st.empty()
+        status_text.text(get_text("analyzing", self.language) + f" (0/{total_tasks})")
+        return progress_bar, status_text
+
+    def update_progress(
+        self,
+        progress_bar: DeltaGenerator,
+        status_text: DeltaGenerator,
+        current: int,
+        total: int,
+        task_description: str | None = None,
+    ) -> None:
+        """Update the visual progress information."""
+        total = max(total, 1)
+        progress_value = min(max(current / total, 0.0), 1.0)
+        progress_bar.progress(progress_value)
+
+        if task_description:
+            status_text.text(f"{task_description} ({current}/{total})")
+        else:
+            status_text.text(
+                get_text("analyzing", self.language) + f" ({current}/{total})"
+            )

--- a/ui/results_display.py
+++ b/ui/results_display.py
@@ -1,9 +1,394 @@
-"""Display analysis results."""
+"""Components to present analysis results within Streamlit."""
 
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+import pandas as pd
 import streamlit as st
 
+from analyzers.base_analyzer import AnalysisResult
+from config.emotion_mappings import get_emotion_display_name
+from config.languages import get_text
+from utils.data_exporter import DataExporter
+from utils.visualizer import SentimentVisualizer
 
-def show_results(results: dict) -> None:
-    """Show analysis results."""
 
-    st.json(results)
+class ResultsDisplayUI:
+    """Handle presentation of analysis outcomes to the user."""
+
+    def __init__(self, language: str = "DE") -> None:
+        self.language = language
+        self.visualizer = SentimentVisualizer(language)
+        self.exporter = DataExporter()
+
+    def render_results_section(
+        self,
+        results: List[Dict[str, AnalysisResult]],
+        analysis_type: str,
+        settings: Dict[str, Any],
+    ) -> None:
+        """Render the entire results area for the current analysis."""
+        st.divider()
+        st.subheader("📊 " + get_text("results", self.language))
+
+        if not results:
+            st.warning("Keine Ergebnisse verfügbar")
+            return
+
+        self._render_results_overview(results, settings)
+
+        if analysis_type == "valence":
+            self._render_valence_results(results, settings)
+        elif analysis_type == "ekman":
+            self._render_ekman_results(results, settings)
+        elif analysis_type == "emotion_arc":
+            self._render_emotion_arc_results(results, settings)
+
+        self._render_export_section(results, analysis_type)
+
+    def _render_results_overview(
+        self,
+        results: List[Dict[str, AnalysisResult]],
+        settings: Dict[str, Any],
+    ) -> None:
+        """Show a quick overview of processed texts and performance metrics."""
+        col1, col2, col3, col4 = st.columns(4)
+
+        with col1:
+            st.metric("Texte analysiert", len(results))
+
+        with col2:
+            model_count = len(settings.get("selected_models", []))
+            st.metric("Modelle verwendet", model_count)
+
+        with col3:
+            total_time = 0.0
+            count = 0
+            for text_results in results:
+                for result in text_results.values():
+                    if result.processing_time:
+                        total_time += result.processing_time
+                        count += 1
+            average_time = total_time / count if count else 0.0
+            st.metric("⌀ Zeit pro Text", f"{average_time:.2f}s")
+
+        with col4:
+            error_count = 0
+            total_count = 0
+            for text_results in results:
+                for result in text_results.values():
+                    total_count += 1
+                    if result.error:
+                        error_count += 1
+            error_rate = (error_count / total_count * 100) if total_count else 0.0
+            st.metric("Fehlerrate", f"{error_rate:.1f}%")
+
+    def _render_valence_results(
+        self, results: List[Dict[str, AnalysisResult]], settings: Dict[str, Any]
+    ) -> None:
+        """Render result views for valence analyses."""
+        st.markdown("### " + get_text("valence_results", self.language))
+
+        if settings.get("benchmark_mode"):
+            self._render_valence_benchmark(results)
+        else:
+            self._render_valence_single(results)
+
+    def _render_valence_benchmark(
+        self, results: List[Dict[str, AnalysisResult]]
+    ) -> None:
+        """Render comparison charts for each text in benchmark mode."""
+        for index, text_results in enumerate(results):
+            with st.expander(f"📄 Text {index + 1}", expanded=index < 3):
+                first_result = next(iter(text_results.values()))
+                text_preview = first_result.text or ""
+                if text_preview:
+                    snippet = text_preview[:200]
+                    suffix = "..." if len(text_preview) > 200 else ""
+                    st.text_area(
+                        "Text",
+                        value=f"{snippet}{suffix}",
+                        height=100,
+                        disabled=True,
+                        key=f"valence_text_{index}",
+                    )
+
+                fig = self.visualizer.create_valence_comparison(text_results)
+                st.plotly_chart(fig, use_container_width=True)
+                self._render_valence_table(text_results, f"valence_table_{index}")
+
+    def _render_valence_single(
+        self, results: List[Dict[str, AnalysisResult]]
+    ) -> None:
+        """Render valence results for a single selected model."""
+        if len(results) > 1:
+            fig = self.visualizer.create_batch_overview(results, "valence")
+            st.plotly_chart(fig, use_container_width=True)
+
+        for index, text_results in enumerate(results):
+            expanded = len(results) == 1
+            with st.expander(f"📄 Text {index + 1}", expanded=expanded):
+                first_result = next(iter(text_results.values()))
+                text_preview = first_result.text or ""
+                if text_preview:
+                    snippet = text_preview[:300]
+                    suffix = "..." if len(text_preview) > 300 else ""
+                    st.text_area(
+                        "Text",
+                        value=f"{snippet}{suffix}",
+                        height=120,
+                        disabled=True,
+                        key=f"single_valence_text_{index}",
+                    )
+                self._render_valence_table(text_results, f"single_valence_table_{index}")
+
+    def _render_valence_table(
+        self, text_results: Dict[str, AnalysisResult], key: str
+    ) -> None:
+        """Render a table summarising valence scores for ``text_results``."""
+        table_data: List[Dict[str, Any]] = []
+
+        for result in text_results.values():
+            if result.error:
+                table_data.append(
+                    {
+                        "Modell": result.model,
+                        "Positiv": "❌",
+                        "Negativ": "❌",
+                        "Neutral": "❌",
+                        "Zeit (s)": f"{result.processing_time:.2f}",
+                        "Fehler": (result.error[:50] + "...") if len(result.error) > 50 else result.error,
+                    }
+                )
+            else:
+                table_data.append(
+                    {
+                        "Modell": result.model,
+                        "Positiv": f"{result.scores.get('positive', 0):.3f}",
+                        "Negativ": f"{result.scores.get('negative', 0):.3f}",
+                        "Neutral": f"{result.scores.get('neutral', 0):.3f}",
+                        "Zeit (s)": f"{result.processing_time:.2f}",
+                        "Fehler": "",
+                    }
+                )
+
+        df = pd.DataFrame(table_data)
+        st.dataframe(df, use_container_width=True, key=key)
+
+    def _render_ekman_results(
+        self, results: List[Dict[str, AnalysisResult]], settings: Dict[str, Any]
+    ) -> None:
+        """Render result views for Ekman emotion analyses."""
+        st.markdown("### " + get_text("ekman_results", self.language))
+
+        if settings.get("benchmark_mode"):
+            for index, text_results in enumerate(results):
+                with st.expander(f"📄 Text {index + 1}", expanded=index < 2):
+                    first_result = next(iter(text_results.values()))
+                    text_preview = first_result.text or ""
+                    if text_preview:
+                        snippet = text_preview[:200]
+                        suffix = "..." if len(text_preview) > 200 else ""
+                        st.text_area(
+                            "Text",
+                            value=f"{snippet}{suffix}",
+                            height=100,
+                            disabled=True,
+                            key=f"ekman_text_{index}",
+                        )
+
+                    fig = self.visualizer.create_ekman_radar_chart(text_results)
+                    st.plotly_chart(fig, use_container_width=True)
+                    self._render_ekman_table(text_results, f"ekman_table_{index}")
+        else:
+            if len(results) > 1:
+                fig = self.visualizer.create_batch_overview(results, "ekman")
+                st.plotly_chart(fig, use_container_width=True)
+
+            for index, text_results in enumerate(results):
+                expanded = len(results) == 1
+                with st.expander(f"📄 Text {index + 1}", expanded=expanded):
+                    first_result = next(iter(text_results.values()))
+                    text_preview = first_result.text or ""
+                    if text_preview:
+                        snippet = text_preview[:300]
+                        suffix = "..." if len(text_preview) > 300 else ""
+                        st.text_area(
+                            "Text",
+                            value=f"{snippet}{suffix}",
+                            height=120,
+                            disabled=True,
+                            key=f"single_ekman_text_{index}",
+                        )
+                    self._render_ekman_table(text_results, f"single_ekman_table_{index}")
+
+    def _render_ekman_table(
+        self, text_results: Dict[str, AnalysisResult], key: str
+    ) -> None:
+        """Render a detailed table for Ekman emotion scores."""
+        emotions = ["joy", "surprise", "fear", "anger", "disgust", "sadness", "contempt"]
+        table_data: List[Dict[str, Any]] = []
+
+        for result in text_results.values():
+            row: Dict[str, Any] = {"Modell": result.model}
+            if result.error:
+                for emotion in emotions:
+                    row[get_emotion_display_name(emotion, self.language)] = "❌"
+                row["Zeit (s)"] = f"{result.processing_time:.2f}"
+                row["Fehler"] = (
+                    (result.error[:30] + "...") if len(result.error) > 30 else result.error
+                )
+            else:
+                for emotion in emotions:
+                    row[get_emotion_display_name(emotion, self.language)] = (
+                        f"{result.scores.get(emotion, 0):.3f}"
+                    )
+                row["Zeit (s)"] = f"{result.processing_time:.2f}"
+                row["Fehler"] = ""
+            table_data.append(row)
+
+        df = pd.DataFrame(table_data)
+        st.dataframe(df, use_container_width=True, key=key)
+
+    def _render_emotion_arc_results(
+        self, results: List[Dict[str, AnalysisResult]], settings: Dict[str, Any]
+    ) -> None:
+        """Render interactive summaries for emotion arc analyses."""
+        st.markdown("### " + get_text("emotion_arc_results", self.language))
+
+        if not results:
+            st.info("Keine Emotion Arc Ergebnisse verfügbar")
+            return
+
+        for index, text_results in enumerate(results):
+            expanded = index == 0
+            with st.expander(f"📄 Text {index + 1}", expanded=expanded):
+                base_result = next(iter(text_results.values()))
+                text_preview = base_result.text or ""
+                if text_preview:
+                    snippet = text_preview[:300]
+                    suffix = "..." if len(text_preview) > 300 else ""
+                    st.text_area(
+                        "Text",
+                        value=f"{snippet}{suffix}",
+                        height=120,
+                        disabled=True,
+                        key=f"emotion_arc_text_{index}",
+                    )
+
+                for model_name, result in text_results.items():
+                    st.markdown(f"#### 🤖 {result.model}")
+                    if result.error:
+                        st.error(f"❌ {result.error}")
+                        continue
+
+                    avg_happiness = result.scores.get("happiness")
+                    if avg_happiness is not None:
+                        st.metric("⌀ Happiness", f"{avg_happiness:.3f}")
+
+                    metadata = result.metadata or {}
+                    arc_analysis = metadata.get("arc_analysis", {})
+                    happiness_scores = metadata.get("happiness_scores", [])
+
+                    if arc_analysis:
+                        archetype = arc_analysis.get("archetype") or "-"
+                        confidence = arc_analysis.get("confidence")
+                        confidence_display = (
+                            f"{confidence:.0%}"
+                            if isinstance(confidence, (int, float))
+                            else "-"
+                        )
+                        col1, col2 = st.columns(2)
+                        with col1:
+                            st.metric(get_text("arc_pattern", self.language), archetype)
+                        with col2:
+                            st.metric(
+                                get_text("arc_confidence", self.language),
+                                confidence_display,
+                            )
+
+                    if happiness_scores:
+                        df = pd.DataFrame(
+                            {
+                                "Segment": list(range(1, len(happiness_scores) + 1)),
+                                "Happiness": happiness_scores,
+                            }
+                        ).set_index("Segment")
+                        st.line_chart(df, height=220)
+
+                    key_moments = []
+                    if arc_analysis:
+                        key_moments = arc_analysis.get("key_moments", []) or []
+                    if key_moments:
+                        st.markdown(f"**{get_text('key_moments', self.language)}:**")
+                        for moment in key_moments:
+                            position = moment.get("position")
+                            moment_type = moment.get("type", "-")
+                            position_display = (
+                                position + 1 if isinstance(position, int) else "-"
+                            )
+                            st.write(f"• {moment_type} (Segment {position_display})")
+
+                    arc_df = self.exporter.arc_to_dataframe(metadata)
+                    if not arc_df.empty:
+                        display_df = arc_df.copy()
+                        if "segment_text" in display_df.columns:
+                            texts = display_df["segment_text"].fillna("").astype(str)
+                            display_df["Segment"] = texts.str.slice(0, 120)
+                            mask = texts.str.len() > 120
+                            display_df.loc[mask, "Segment"] = (
+                                display_df.loc[mask, "Segment"] + "..."
+                            )
+                            display_df = display_df.drop(columns=["segment_text"])
+                        st.dataframe(
+                            display_df,
+                            use_container_width=True,
+                            key=f"emotion_arc_table_{index}_{model_name.replace('/', '_')}",
+                        )
+
+    def _render_export_section(
+        self, results: List[Dict[str, AnalysisResult]], analysis_type: str
+    ) -> None:
+        """Render download buttons for multiple export formats."""
+        st.divider()
+        st.subheader("💾 " + get_text("export", self.language))
+
+        df = self.exporter.results_to_dataframe(results, analysis_type)
+        if df.empty:
+            st.warning("Keine Daten zum Exportieren verfügbar")
+            return
+
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        col1, col2, col3 = st.columns(3)
+
+        with col1:
+            csv_data = self.exporter.export_to_csv(df)
+            csv_name = f"sentiment_analysis_{analysis_type}_{timestamp}.csv"
+            st.download_button(
+                label=get_text("export_csv", self.language),
+                data=csv_data,
+                file_name=csv_name,
+                mime="text/csv",
+            )
+
+        with col2:
+            excel_data = self.exporter.export_to_excel(df)
+            excel_name = f"sentiment_analysis_{analysis_type}_{timestamp}.xlsx"
+            st.download_button(
+                label=get_text("export_excel", self.language),
+                data=excel_data,
+                file_name=excel_name,
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+
+        with col3:
+            json_data = self.exporter.export_to_json(results)
+            json_name = f"sentiment_analysis_{analysis_type}_{timestamp}.json"
+            st.download_button(
+                label="Export als JSON",
+                data=json_data,
+                file_name=json_name,
+                mime="application/json",
+            )

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -1,9 +1,219 @@
-"""Sidebar components for the Streamlit app."""
+"""Streamlit sidebar components for the Sentiment Analysis Toolkit."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
 
 import streamlit as st
 
+from config.languages import get_text
+from config.settings import Settings
 
-def render_sidebar() -> None:
-    """Render the sidebar."""
 
-    st.sidebar.title("Options")
+class SidebarUI:
+    """Render and manage all sidebar controls."""
+
+    def __init__(self) -> None:
+        self.language = st.session_state.get("language", Settings.DEFAULT_LANGUAGE)
+
+    def render(self) -> Dict[str, Any]:
+        """Render the full sidebar and return the collected settings."""
+        settings: Dict[str, Any] = {}
+
+        with st.sidebar:
+            settings["language"] = self._render_language_selector()
+            self.language = settings["language"]
+
+            st.divider()
+            settings["analysis_type"] = self._render_analysis_type_selector()
+
+            st.divider()
+            model_settings = self._render_model_selector(settings["analysis_type"])
+            settings.update(model_settings)
+
+            st.divider()
+            advanced_settings = self._render_advanced_settings(
+                settings["analysis_type"], settings.get("selected_models", [])
+            )
+            settings.update(advanced_settings)
+
+            st.divider()
+            self._render_info_section()
+
+        return settings
+
+    def _render_language_selector(self) -> str:
+        """Render the language selector and update the session state if needed."""
+        st.subheader("🌐 " + get_text("language_settings", self.language))
+
+        languages = Settings.SUPPORTED_LANGUAGES
+        current_language = st.session_state.get("language", Settings.DEFAULT_LANGUAGE)
+        try:
+            index = languages.index(current_language)
+        except ValueError:
+            index = 0
+
+        language = st.selectbox(
+            "Language / Sprache",
+            options=languages,
+            index=index,
+            key="language_selector",
+        )
+
+        if language != current_language:
+            st.session_state["language"] = language
+            self.language = language
+            st.rerun()
+
+        return language
+
+    def _render_analysis_type_selector(self) -> str:
+        """Render the analysis type selector."""
+        st.subheader("🎯 " + get_text("analysis_type", self.language))
+
+        analysis_options = {
+            "valence": get_text("valence_results", self.language),
+            "ekman": get_text("ekman_results", self.language),
+            "emotion_arc": get_text("emotion_arc_results", self.language),
+        }
+
+        return st.selectbox(
+            get_text("analysis_type", self.language),
+            options=list(analysis_options.keys()),
+            format_func=lambda key: analysis_options.get(key, key.title()),
+            key="analysis_type_selector",
+        )
+
+    def _render_model_selector(self, analysis_type: str) -> Dict[str, Any]:
+        """Render the model selection widget depending on the analysis type."""
+        st.subheader("🤖 " + get_text("model_selection", self.language))
+
+        available_models = self._get_available_models_for_analysis(analysis_type)
+        benchmark_mode = st.checkbox(
+            get_text("benchmark_mode", self.language),
+            help=get_text("benchmark_description", self.language),
+            key="benchmark_mode",
+        )
+
+        if benchmark_mode:
+            selected_models = available_models
+            if available_models:
+                st.info(f"📊 {len(available_models)} Modelle ausgewählt für Benchmark")
+        else:
+            if available_models:
+                default_index = 0
+                if "selected_models" in st.session_state:
+                    try:
+                        default_model = st.session_state["selected_models"][0]
+                        default_index = available_models.index(default_model)
+                    except (IndexError, ValueError):
+                        default_index = 0
+
+                selected_model = st.selectbox(
+                    get_text("single_model", self.language),
+                    options=available_models,
+                    index=default_index,
+                    format_func=lambda name: Settings.MODELS[name].display_name,
+                    key="single_model_selector",
+                )
+                selected_models = [selected_model]
+            else:
+                st.error("Keine Modelle für diesen Analyse-Typ verfügbar")
+                selected_models = []
+
+        st.session_state["selected_models"] = selected_models
+        st.session_state["benchmark_mode"] = benchmark_mode
+
+        return {
+            "benchmark_mode": benchmark_mode,
+            "selected_models": selected_models,
+        }
+
+    def _render_advanced_settings(
+        self, analysis_type: str, selected_models: List[str]
+    ) -> Dict[str, Any]:
+        """Render advanced configuration controls."""
+        settings: Dict[str, Any] = {}
+
+        with st.expander("⚙️ Erweiterte Einstellungen"):
+            if analysis_type == "emotion_arc":
+                settings["n_segments"] = st.slider(
+                    "Anzahl Segmente für Arc-Analyse",
+                    min_value=10,
+                    max_value=50,
+                    value=20,
+                    help="Mehr Segmente = detailliertere Analyse, aber langsamere Verarbeitung",
+                )
+
+            if any(model == "apt-5-nano" for model in selected_models):
+                settings["reasoning_effort"] = st.selectbox(
+                    "OpenAI Reasoning Effort",
+                    options=["minimal", "low", "medium", "high"],
+                    index=0,
+                    help="Höhere Werte = bessere Qualität, aber langsamere Verarbeitung",
+                )
+                settings["verbosity"] = st.selectbox(
+                    "OpenAI Verbosity",
+                    options=["low", "medium", "high"],
+                    index=0,
+                )
+
+            settings["batch_size"] = st.slider(
+                "Batch-Größe",
+                min_value=1,
+                max_value=Settings.MAX_BATCH_SIZE,
+                value=min(Settings.DEFAULT_BATCH_SIZE, Settings.MAX_BATCH_SIZE),
+                help="Anzahl Texte die parallel verarbeitet werden",
+            )
+
+            settings["timeout"] = st.slider(
+                "Timeout (Sekunden)",
+                min_value=10,
+                max_value=120,
+                value=Settings.REQUEST_TIMEOUT,
+                help="Maximale Wartezeit pro Anfrage",
+            )
+
+        return settings
+
+    def _render_info_section(self) -> None:
+        """Render the informational help section."""
+        with st.expander("ℹ️ Information"):
+            st.markdown(
+                """
+                **Sentiment Analysis Toolkit**
+
+                **Verfügbare Modelle:**
+                - 🧠 OpenAI GPT-5 Nano (apt-5-nano)
+                - 🤖 DeepSeek Chat
+                - 🤗 HuggingFace BART Large
+                - 🤗 HuggingFace RoBERTa Base
+                - 🤗 SiEBERT (Sentiment RoBERTa)
+                - 📊 VADER (Klassisches Lexikon)
+
+                **Analyse-Typen:**
+                - **Valence**: Positiv/Negativ/Neutral
+                - **Ekman**: 7 Basis-Emotionen mit Synonymen
+                - **Emotion Arc**: Happiness-Tracking über Textverlauf
+
+                **Features:**
+                - Benchmark-Modus für Modell-Vergleiche
+                - Batch-Verarbeitung für multiple Texte
+                - CSV/Excel/JSON Export
+                - Interaktive Visualisierungen
+                """
+            )
+
+    def _get_available_models_for_analysis(self, analysis_type: str) -> List[str]:
+        """Return the model identifiers supporting ``analysis_type``."""
+        available_models: List[str] = []
+
+        for model_name, model_config in Settings.MODELS.items():
+            if analysis_type == "valence" and model_config.supports_valence:
+                available_models.append(model_name)
+            elif analysis_type == "ekman" and model_config.supports_ekman:
+                available_models.append(model_name)
+            elif analysis_type == "emotion_arc" and model_config.supports_emotion_arc:
+                available_models.append(model_name)
+
+        return available_models

--- a/utils/text_processor.py
+++ b/utils/text_processor.py
@@ -72,8 +72,8 @@ class TextProcessor:
             sentences = sent_tokenize(cleaned)
             return [self.clean_text(sent) for sent in sentences if sent.strip()]
         except Exception:
-            # Fallback: Split by periods
-            sentences = cleaned.split('.')
+            # Fallback: Split on common sentence punctuation
+            sentences = re.split(r"[.!?]+", cleaned)
             return [self.clean_text(sent) for sent in sentences if sent.strip()]
 
     def chunk_text(self, text: str, max_tokens: int = 500, overlap: int = 50) -> List[str]:


### PR DESCRIPTION
## Summary
- replace the minimal Streamlit stubs with fully featured sidebar, input, and result display components
- wire the UI into the existing analyzer implementations so that valence, Ekman, and emotion arc runs can execute from the app, including richer visualisations
- improve compatibility by allowing VADER for emotion-arc selection and adding a regex-based sentence split fallback when NLTK data is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c932fe427083278378a926f32c5ecf