### PR TITLE
Fix benchmark mode session state handling

### DIFF
--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -89,6 +89,7 @@ class SidebarUI:
         st.subheader("🤖 " + get_text("model_selection", self.language))
 
         available_models = self._get_available_models_for_analysis(analysis_type)
+        st.session_state.setdefault("benchmark_mode", False)
         benchmark_mode = st.checkbox(
             get_text("benchmark_mode", self.language),
             help=get_text("benchmark_description", self.language),
@@ -122,7 +123,6 @@ class SidebarUI:
                 selected_models = []
 
         st.session_state["selected_models"] = selected_models
-        st.session_state["benchmark_mode"] = benchmark_mode
 
         return {
             "benchmark_mode": benchmark_mode,


### PR DESCRIPTION
## Summary
- ensure the benchmark mode checkbox initializes its session state before rendering
- rely on Streamlit's widget handling for benchmark mode while preserving selected model tracking

## Testing
- streamlit run app.py (toggled benchmark mode checkbox)


------
https://chatgpt.com/codex/tasks/task_e_68c9537d683083278d56590085d68223