### PR TITLE
Remove base emotion names from synonyms

### DIFF
--- a/config/emotion_mappings.py
+++ b/config/emotion_mappings.py
@@ -44,7 +44,7 @@ EKMAN_EMOTIONS = {
         "name_en": "Disgust",
         "synonyms": [
             "revulsion", "repulsion", "nausea", "loathing", "abhorrence",
-            "aversion", "distaste", "repugnance", "contempt", "disdain",
+            "aversion", "distaste", "repugnance", "disdain",
             "revulsion", "sickening", "disgusting", "revolting"
         ]
     },


### PR DESCRIPTION
## Summary
- removed the top-level emotion name from the disgust synonyms list to avoid duplication
- confirmed no other Ekman base emotions appear within synonym entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97957c4848327ac85ce47c96352e2