### PR TITLE
Refine external analyzers to require real model outputs

### DIFF
--- a/analyzers/deepseek_analyzer.py
+++ b/analyzers/deepseek_analyzer.py
@@ -1,52 +1,34 @@
-"""Keyword-basierter DeepSeek Analyzer als Fallback."""
+"""DeepSeek-based analyzer that queries the API when available."""
 
 from __future__ import annotations
 
+import json
 import time
-from collections import Counter
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
 
 from analyzers.base_analyzer import AnalysisResult, BaseAnalyzer
 from config.emotion_mappings import EKMAN_EMOTIONS
 
-_POSITIVE_WORDS = {
-    "innovative",
-    "efficient",
-    "accurate",
-    "happy",
-    "joyful",
-    "success",
-    "optimistic",
-    "improved",
-    "solution",
-    "amazing",
-}
-
-_NEGATIVE_WORDS = {
-    "problem",
-    "issue",
-    "error",
-    "sad",
-    "angry",
-    "failure",
-    "bug",
-    "worry",
-    "concern",
-    "difficult",
-}
-
 
 class DeepSeekAnalyzer(BaseAnalyzer):
-    """Heuristischer Analyzer als Ersatz für das DeepSeek-Modell."""
+    """Analyzer that delegates emotion detection to DeepSeek models."""
 
     def __init__(
         self, api_config: Optional[Any] = None, model_name: str = "deepseek-chat"
     ) -> None:
         super().__init__(model_name=model_name, api_config=api_config)
-        self._api_key_available = bool(getattr(api_config, "primary_key", None))
+        self._api_key = getattr(self.api_config, "primary_key", "") or ""
+        self._base_url = getattr(self.api_config, "base_url", "") or "https://api.deepseek.com"
+        self._timeout = getattr(self.api_config, "timeout", 30)
+        self._session, self._endpoint = self._initialize_session()
+        self._api_key_available = self._session is not None
 
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def analyze_single(self, text: str, analysis_type: str, **kwargs) -> AnalysisResult:
-        tokens = self._tokenize(text)
         metadata = {
             "provider": "deepseek",
             "model": self.model_name,
@@ -55,14 +37,16 @@ class DeepSeekAnalyzer(BaseAnalyzer):
 
         start_time = time.time()
         if analysis_type == "valence":
-            scores = self._analyze_valence(tokens)
+            scores, available = self._analyze_valence(text)
         elif analysis_type == "ekman":
-            scores = self._analyze_ekman(tokens)
+            scores, available = self._analyze_ekman(text)
         elif analysis_type == "emotion_arc":
-            scores = self._analyze_emotion_arc(tokens)
+            valence_scores, available = self._analyze_valence(text)
+            scores = {"happiness": self._derive_happiness(valence_scores)}
         else:
             raise ValueError(f"Unsupported analysis type: {analysis_type}")
 
+        metadata["analysis_available"] = available
         processing_time = time.time() - start_time
         return AnalysisResult(
             text=text,
@@ -80,46 +64,151 @@ class DeepSeekAnalyzer(BaseAnalyzer):
         return True
 
     # ------------------------------------------------------------------
-    # Hilfsfunktionen
+    # Internal helpers
     # ------------------------------------------------------------------
-    def _tokenize(self, text: str) -> List[str]:
-        return [token.lower() for token in text.split() if token.strip()]
+    def _initialize_session(self) -> Tuple[Optional[requests.Session], Optional[str]]:
+        if not self._api_key or not self._base_url:
+            return None, None
 
-    def _normalise(self, scores: Dict[str, float]) -> Dict[str, float]:
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            }
+        )
+        endpoint = f"{self._base_url.rstrip('/')}/chat/completions"
+        return session, endpoint
+
+    def _analyze_valence(self, text: str) -> Tuple[Dict[str, float], bool]:
+        labels = ["positive", "negative", "neutral"]
+        return self._generate_scores(text, labels)
+
+    def _analyze_ekman(self, text: str) -> Tuple[Dict[str, float], bool]:
+        labels = list(EKMAN_EMOTIONS.keys())
+        return self._generate_scores(text, labels)
+
+    def _generate_scores(
+        self, text: str, labels: List[str]
+    ) -> Tuple[Dict[str, float], bool]:
+        raw_scores = self._request_model_scores(text, labels)
+        if raw_scores is None:
+            return self._zero_scores(labels), False
+
+        sanitized = self._sanitize_scores(raw_scores, labels)
+        if sanitized is None:
+            return self._zero_scores(labels), False
+
+        normalised = self._normalise_scores(sanitized)
+        return normalised, True
+
+    def _derive_happiness(self, valence_scores: Dict[str, float]) -> float:
+        positive = max(0.0, valence_scores.get("positive", 0.0))
+        neutral = max(0.0, valence_scores.get("neutral", 0.0))
+        happiness = positive + 0.4 * neutral
+        return max(0.0, min(1.0, happiness))
+
+    def _request_model_scores(
+        self, text: str, labels: List[str]
+    ) -> Optional[Dict[str, float]]:
+        if self._session is None or self._endpoint is None:
+            return None
+
+        prompt = self._build_prompt(text, labels)
+        payload = {
+            "model": self.model_name,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are an assistant that returns only JSON objects with emotion probabilities.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            "response_format": {"type": "json_object"},
+        }
+
+        try:
+            response = self._session.post(
+                self._endpoint,
+                json=payload,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - defensive
+            self.logger.error("DeepSeek API request failed: %s", exc)
+            return None
+
+        try:
+            data = response.json()
+        except ValueError:  # pragma: no cover - defensive
+            self.logger.error("DeepSeek API returned a non-JSON payload")
+            return None
+
+        message_content = self._extract_message_content(data)
+        if not message_content:
+            return None
+
+        try:
+            parsed = json.loads(message_content)
+        except json.JSONDecodeError:
+            self.logger.error("Failed to decode DeepSeek response as JSON: %s", message_content)
+            return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        return {label: float(parsed.get(label, 0.0)) for label in labels}
+
+    def _build_prompt(self, text: str, labels: List[str]) -> str:
+        label_list = ", ".join(labels)
+        return (
+            "Estimate probability scores for the following emotions: "
+            f"{label_list}. Return a JSON object with numeric probabilities between 0 and 1 that sum to 1. "
+            "Do not include explanations."
+            f" Text: ```{text}```"
+        )
+
+    def _extract_message_content(self, payload: Dict[str, Any]) -> str:
+        choices = payload.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                if not isinstance(choice, dict):
+                    continue
+                message = choice.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str) and content.strip():
+                        return content.strip()
+        return ""
+
+    def _sanitize_scores(
+        self, raw_scores: Dict[str, float], labels: List[str]
+    ) -> Optional[Dict[str, float]]:
+        sanitized: Dict[str, float] = {}
+        total = 0.0
+        for label in labels:
+            value = raw_scores.get(label, 0.0)
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                numeric = 0.0
+            if numeric < 0:
+                numeric = 0.0
+            sanitized[label] = numeric
+            total += numeric
+
+        if total <= 0:
+            return None
+        return sanitized
+
+    def _normalise_scores(self, scores: Dict[str, float]) -> Dict[str, float]:
         total = sum(scores.values())
         if total <= 0:
-            uniform = 1.0 / len(scores) if scores else 0.0
-            return {key: uniform for key in scores}
+            return {key: 0.0 for key in scores}
         return {key: value / total for key, value in scores.items()}
 
-    def _analyze_valence(self, tokens: Iterable[str]) -> Dict[str, float]:
-        token_list = list(tokens)
-        counter = Counter(token_list)
-        positive_hits = sum(counter[word] for word in _POSITIVE_WORDS)
-        negative_hits = sum(counter[word] for word in _NEGATIVE_WORDS)
-        neutral_hits = max(0, len(token_list) - (positive_hits + negative_hits))
-
-        scores = {
-            "positive": positive_hits + 1.0,
-            "negative": negative_hits + 1.0,
-            "neutral": neutral_hits + 1.0,
-        }
-        return self._normalise(scores)
-
-    def _analyze_ekman(self, tokens: Iterable[str]) -> Dict[str, float]:
-        token_list = list(tokens)
-        counter = Counter(token_list)
-        scores: Dict[str, float] = {}
-        for emotion, data in EKMAN_EMOTIONS.items():
-            synonyms = {emotion.lower(), *[syn.lower() for syn in data["synonyms"]]}
-            hits = sum(counter[word] for word in synonyms)
-            scores[emotion] = float(hits + 1.0)
-        return self._normalise(scores)
-
-    def _analyze_emotion_arc(self, tokens: Iterable[str]) -> Dict[str, float]:
-        valence = self._analyze_valence(tokens)
-        happiness = valence.get("positive", 0.0) + 0.4 * valence.get("neutral", 0.0)
-        return {"happiness": max(0.0, min(1.0, happiness))}
+    def _zero_scores(self, labels: List[str]) -> Dict[str, float]:
+        return {label: 0.0 for label in labels}
 
 
 __all__ = ["DeepSeekAnalyzer"]

--- a/analyzers/huggingface_analyzer.py
+++ b/analyzers/huggingface_analyzer.py
@@ -175,12 +175,16 @@ class HuggingFaceAnalyzer(BaseAnalyzer):
         target_emotions = list(EKMAN_EMOTIONS.keys())
 
         if self.model_name in self._SENTIMENT_MODELS:
-            return {emotion: 0.1 for emotion in target_emotions}
+            raise RuntimeError(
+                "Ekman analysis is not supported for sentiment-only models"
+            )
 
         if self.model_name in self._FILL_MASK_MODELS:
             return self._fill_mask_analysis(text, target_emotions)
 
-        return self._fallback_distribution(target_emotions)
+        raise RuntimeError(
+            f"Ekman analysis requires a supported fill-mask model, got {self.model_name}"
+        )
 
     def _analyze_happiness(self, text: str, **kwargs) -> Dict[str, float]:
         """Analysiert Happiness für Emotion Arc"""

--- a/analyzers/openai_analyzer.py
+++ b/analyzers/openai_analyzer.py
@@ -1,54 +1,31 @@
-"""Keyword-basierter OpenAI Analyzer als Fallback."""
+"""OpenAI-based analyzer that retrieves probabilities from the API when possible."""
 
 from __future__ import annotations
 
+import json
 import time
-from collections import Counter
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+from openai import OpenAI
 
 from analyzers.base_analyzer import AnalysisResult, BaseAnalyzer
 from config.emotion_mappings import EKMAN_EMOTIONS
 
-_POSITIVE_WORDS = {
-    "good",
-    "great",
-    "excellent",
-    "happy",
-    "joy",
-    "love",
-    "awesome",
-    "fantastic",
-    "wonderful",
-    "pleasant",
-    "delight",
-}
-
-_NEGATIVE_WORDS = {
-    "bad",
-    "terrible",
-    "awful",
-    "sad",
-    "hate",
-    "angry",
-    "horrible",
-    "disgust",
-    "fear",
-    "upset",
-    "annoyed",
-}
-
 
 class OpenAIAnalyzer(BaseAnalyzer):
-    """Ein heuristischer Analyzer, der OpenAI-Modelle simuliert."""
+    """Analyzer that delegates emotion detection to OpenAI models."""
 
     def __init__(
         self, api_config: Optional[Any] = None, model_name: str = "apt-5-nano"
     ) -> None:
         super().__init__(model_name=model_name, api_config=api_config)
-        self._api_key_available = bool(getattr(api_config, "primary_key", None))
+        self._client = self._initialize_client()
+        self._api_key_available = self._client is not None
 
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def analyze_single(self, text: str, analysis_type: str, **kwargs) -> AnalysisResult:
-        tokens = self._tokenize(text)
         metadata = {
             "provider": "openai",
             "model": self.model_name,
@@ -57,14 +34,16 @@ class OpenAIAnalyzer(BaseAnalyzer):
 
         start_time = time.time()
         if analysis_type == "valence":
-            scores = self._analyze_valence(tokens)
+            scores, available = self._analyze_valence(text)
         elif analysis_type == "ekman":
-            scores = self._analyze_ekman(tokens)
+            scores, available = self._analyze_ekman(text)
         elif analysis_type == "emotion_arc":
-            scores = self._analyze_emotion_arc(tokens)
+            valence_scores, available = self._analyze_valence(text)
+            scores = {"happiness": self._derive_happiness(valence_scores)}
         else:
             raise ValueError(f"Unsupported analysis type: {analysis_type}")
 
+        metadata["analysis_available"] = available
         processing_time = time.time() - start_time
         return AnalysisResult(
             text=text,
@@ -82,46 +61,178 @@ class OpenAIAnalyzer(BaseAnalyzer):
         return True
 
     # ------------------------------------------------------------------
-    # interne Hilfsfunktionen
+    # Internal helpers
     # ------------------------------------------------------------------
-    def _tokenize(self, text: str) -> List[str]:
-        return [token.lower() for token in text.split() if token.strip()]
+    def _initialize_client(self) -> Optional[OpenAI]:
+        api_key = getattr(self.api_config, "primary_key", None)
+        if not api_key:
+            return None
 
-    def _normalise(self, scores: Dict[str, float]) -> Dict[str, float]:
+        base_url = getattr(self.api_config, "base_url", None)
+        try:
+            if base_url:
+                return OpenAI(api_key=api_key, base_url=base_url)
+            return OpenAI(api_key=api_key)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error("Failed to initialize OpenAI client: %s", exc)
+            return None
+
+    def _analyze_valence(self, text: str) -> Tuple[Dict[str, float], bool]:
+        labels = ["positive", "negative", "neutral"]
+        return self._generate_scores(text, labels)
+
+    def _analyze_ekman(self, text: str) -> Tuple[Dict[str, float], bool]:
+        labels = list(EKMAN_EMOTIONS.keys())
+        return self._generate_scores(text, labels)
+
+    def _generate_scores(
+        self, text: str, labels: List[str]
+    ) -> Tuple[Dict[str, float], bool]:
+        raw_scores = self._request_model_scores(text, labels)
+        if raw_scores is None:
+            return self._zero_scores(labels), False
+
+        sanitized = self._sanitize_scores(raw_scores, labels)
+        if sanitized is None:
+            return self._zero_scores(labels), False
+
+        normalised = self._normalise_scores(sanitized)
+        return normalised, True
+
+    def _derive_happiness(self, valence_scores: Dict[str, float]) -> float:
+        positive = max(0.0, valence_scores.get("positive", 0.0))
+        neutral = max(0.0, valence_scores.get("neutral", 0.0))
+        happiness = positive + 0.5 * neutral
+        return max(0.0, min(1.0, happiness))
+
+    def _request_model_scores(
+        self, text: str, labels: List[str]
+    ) -> Optional[Dict[str, float]]:
+        if self._client is None:
+            return None
+
+        prompt = self._build_prompt(text, labels)
+        try:
+            response = self._client.responses.create(
+                model=self.model_name,
+                input=prompt,
+                response_format={"type": "json_object"},
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error("OpenAI API request failed: %s", exc)
+            return None
+
+        content = self._extract_text_from_response(response)
+        if not content:
+            return None
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            self.logger.error("Failed to decode OpenAI response as JSON: %s", content)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        return {label: float(data.get(label, 0.0)) for label in labels}
+
+    def _build_prompt(self, text: str, labels: List[str]) -> str:
+        label_list = ", ".join(labels)
+        return (
+            "You are an assistant that performs emotion probability estimation.\n"
+            f"Return a JSON object with numeric probabilities for the following labels: {label_list}.\n"
+            "Probabilities must be values between 0 and 1 and sum to 1.\n"
+            "Respond with JSON only without additional commentary.\n"
+            f"Text: ```{text}```"
+        )
+
+    def _extract_text_from_response(self, response: Any) -> str:
+        direct_text = getattr(response, "output_text", None)
+        if isinstance(direct_text, str) and direct_text.strip():
+            return direct_text.strip()
+
+        response_dict = self._to_dict(response)
+        if not response_dict:
+            return ""
+
+        output_text = response_dict.get("output_text")
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text.strip()
+
+        output_items = response_dict.get("output")
+        if isinstance(output_items, list):
+            parts: List[str] = []
+            for item in output_items:
+                if not isinstance(item, dict):
+                    continue
+                for content in item.get("content", []):
+                    if isinstance(content, dict):
+                        text_value = content.get("text")
+                        if isinstance(text_value, str):
+                            parts.append(text_value)
+            if parts:
+                joined = "".join(parts).strip()
+                if joined:
+                    return joined
+
+        choices = response_dict.get("choices")
+        if isinstance(choices, list) and choices:
+            message = choices[0].get("message") if isinstance(choices[0], dict) else None
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str) and content.strip():
+                    return content.strip()
+
+        return ""
+
+    def _to_dict(self, response: Any) -> Dict[str, Any]:
+        if hasattr(response, "model_dump"):
+            try:
+                data = response.model_dump()
+                if isinstance(data, dict):
+                    return data
+            except Exception:  # pragma: no cover - defensive
+                return {}
+        if hasattr(response, "dict"):
+            try:
+                data = response.dict()
+                if isinstance(data, dict):
+                    return data
+            except Exception:  # pragma: no cover - defensive
+                return {}
+        if isinstance(response, dict):
+            return response
+        return {}
+
+    def _sanitize_scores(
+        self, raw_scores: Dict[str, float], labels: List[str]
+    ) -> Optional[Dict[str, float]]:
+        sanitized: Dict[str, float] = {}
+        total = 0.0
+        for label in labels:
+            value = raw_scores.get(label, 0.0)
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                numeric = 0.0
+            if numeric < 0:
+                numeric = 0.0
+            sanitized[label] = numeric
+            total += numeric
+
+        if total <= 0:
+            return None
+        return sanitized
+
+    def _normalise_scores(self, scores: Dict[str, float]) -> Dict[str, float]:
         total = sum(scores.values())
         if total <= 0:
-            uniform = 1.0 / len(scores) if scores else 0.0
-            return {key: uniform for key in scores}
+            return {key: 0.0 for key in scores}
         return {key: value / total for key, value in scores.items()}
 
-    def _analyze_valence(self, tokens: Iterable[str]) -> Dict[str, float]:
-        token_list = list(tokens)
-        counter = Counter(token_list)
-        positive_hits = sum(counter[word] for word in _POSITIVE_WORDS)
-        negative_hits = sum(counter[word] for word in _NEGATIVE_WORDS)
-        neutral_hits = max(0, len(token_list) - (positive_hits + negative_hits))
-
-        scores = {
-            "positive": positive_hits + 1.0,
-            "negative": negative_hits + 1.0,
-            "neutral": neutral_hits + 1.0,
-        }
-        return self._normalise(scores)
-
-    def _analyze_ekman(self, tokens: Iterable[str]) -> Dict[str, float]:
-        token_list = list(tokens)
-        counter = Counter(token_list)
-        scores: Dict[str, float] = {}
-        for emotion, data in EKMAN_EMOTIONS.items():
-            synonyms = {emotion.lower(), *[syn.lower() for syn in data["synonyms"]]}
-            hits = sum(counter[word] for word in synonyms)
-            scores[emotion] = float(hits + 1.0)
-        return self._normalise(scores)
-
-    def _analyze_emotion_arc(self, tokens: Iterable[str]) -> Dict[str, float]:
-        valence = self._analyze_valence(tokens)
-        happiness = valence.get("positive", 0.0) + 0.5 * valence.get("neutral", 0.0)
-        return {"happiness": max(0.0, min(1.0, happiness))}
+    def _zero_scores(self, labels: List[str]) -> Dict[str, float]:
+        return {label: 0.0 for label in labels}
 
 
 __all__ = ["OpenAIAnalyzer"]


### PR DESCRIPTION
## Summary
- raise explicit errors when HuggingFace models cannot perform Ekman analysis instead of fabricating scores
- replace the heuristic OpenAI analyzer with an API-driven implementation that only normalizes real model outputs
- update the DeepSeek analyzer to use the HTTP API and report unavailable scores without uniform smoothing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97d26fb2483279a132e8e6af8a998