### PR TITLE
Refine Ekman scoring and rename OpenAI model

### DIFF
--- a/analyzers/openai_analyzer.py
+++ b/analyzers/openai_analyzer.py
@@ -16,7 +16,7 @@ class OpenAIAnalyzer(BaseAnalyzer):
     """Analyzer that delegates emotion detection to OpenAI models."""
 
     def __init__(
-        self, api_config: Optional[Any] = None, model_name: str = "apt-5-nano"
+        self, api_config: Optional[Any] = None, model_name: str = "gpt-5-nano"
     ) -> None:
         super().__init__(model_name=model_name, api_config=api_config)
         self._client = self._initialize_client()

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,8 +35,8 @@ class Settings:
 
     # Verfügbare Modelle
     MODELS = {
-        "apt-5-nano": ModelConfig(
-            name="apt-5-nano",
+        "gpt-5-nano": ModelConfig(
+            name="gpt-5-nano",
             display_name="OpenAI GPT-5 Nano",
             api_type="openai_reasoning",
             max_tokens=8000,

--- a/models/emotion_arc_analyzer.py
+++ b/models/emotion_arc_analyzer.py
@@ -76,7 +76,7 @@ class EmotionArcAnalyzer:
         try:
             config = self.api_manager.get_api_config("openai_reasoning")
             if getattr(config, "primary_key", None):
-                self.analyzers["apt-5-nano"] = OpenAIAnalyzer(config)
+                self.analyzers["gpt-5-nano"] = OpenAIAnalyzer(config)
         except Exception:  # pragma: no cover - defensive initialisation
             pass
 
@@ -99,7 +99,7 @@ class EmotionArcAnalyzer:
         self.analyzers["vader"] = VADERAnalyzer()
 
     def analyze_arc(
-        self, text: str, model: str = "apt-5-nano", n_segments: int = 20, **kwargs
+        self, text: str, model: str = "gpt-5-nano", n_segments: int = 20, **kwargs
     ) -> Dict[str, Any]:
         """Analysiert den emotionalen Bogen eines Textes."""
         segments = self.text_processor.extract_segments_for_arc(text, n_segments)

--- a/models/valence_analyzer.py
+++ b/models/valence_analyzer.py
@@ -27,7 +27,7 @@ class ValenceAnalyzer:
         try:
             config = self.api_manager.get_api_config("openai_reasoning")
             if getattr(config, "primary_key", None):
-                self.analyzers["apt-5-nano"] = OpenAIAnalyzer(config)
+                self.analyzers["gpt-5-nano"] = OpenAIAnalyzer(config)
         except Exception:  # pragma: no cover - defensive initialisation
             pass
 

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -147,7 +147,7 @@ class SidebarUI:
                     help="Mehr Segmente = detailliertere Analyse, aber langsamere Verarbeitung",
                 )
 
-            if any(model == "apt-5-nano" for model in selected_models):
+            if any(model == "gpt-5-nano" for model in selected_models):
                 settings["reasoning_effort"] = st.selectbox(
                     "OpenAI Reasoning Effort",
                     options=["minimal", "low", "medium", "high"],
@@ -186,7 +186,7 @@ class SidebarUI:
                 **Sentiment Analysis Toolkit**
 
                 **Verfügbare Modelle:**
-                - 🧠 OpenAI GPT-5 Nano (apt-5-nano)
+                - 🧠 OpenAI GPT-5 Nano (gpt-5-nano)
                 - 🤖 DeepSeek Chat
                 - 🤗 HuggingFace BART Large
                 - 🤗 HuggingFace RoBERTa Base


### PR DESCRIPTION
## Summary
- stop normalising Ekman synonym scores so each emotion keeps its individual intensity while keeping values within the 0-1 range
- rename the OpenAI reasoning model identifier from apt-5-nano to gpt-5-nano across analyzers, settings and UI text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98e3817508327943da6343021d411