### PR TITLE
Update OpenAI analyzer to use intensity scores

### DIFF
--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -2,11 +2,12 @@
 Tests for analyzer classes.
 """
 
-from analyzers.openai_analyzer import OpenAIAnalyzer
 from analyzers.deepseek_analyzer import DeepSeekAnalyzer
 from analyzers.huggingface_analyzer import HuggingFaceAnalyzer
 from analyzers.vader_analyzer import VaderAnalyzer
 from analyzers.base_analyzer import AnalysisResult
+from analyzers.openai_analyzer import OpenAIAnalyzer
+from config.emotion_mappings import EKMAN_EMOTIONS
 
 
 def test_analyzers_return_standard_result() -> None:
@@ -32,3 +33,28 @@ def test_analyzers_return_standard_result() -> None:
     batch_results = analyzers[0][0].analyze_batch([text, text], analysis_type="valence")
     assert len(batch_results) == 2
     assert all(isinstance(item, AnalysisResult) for item in batch_results)
+
+
+def test_openai_ekman_scores_preserve_intensity(monkeypatch) -> None:
+    analyzer = OpenAIAnalyzer()
+    labels = list(EKMAN_EMOTIONS.keys())
+
+    def fake_request(text: str, requested_labels):
+        assert requested_labels == labels
+        return {
+            labels[0]: 1.5,  # Should clamp to 1.0
+            labels[1]: -0.2,  # Should clamp to 0.0
+            labels[2]: 0.6,
+        }
+
+    monkeypatch.setattr(analyzer, "_request_model_scores", fake_request)
+
+    scores, available = analyzer._analyze_ekman("example text")
+
+    assert available is True
+    assert scores[labels[0]] == 1.0
+    assert scores[labels[1]] == 0.0
+    assert scores[labels[2]] == 0.6
+    assert sum(scores.values()) > 1.0
+    for label in labels[3:]:
+        assert scores[label] == 0.0


### PR DESCRIPTION
## Summary
- return clamped intensity scores from the OpenAI analyzer rather than normalised probabilities
- update the OpenAI prompt to describe independent intensity values in the 0–1 range
- add a unit test that confirms Ekman intensity outputs retain their magnitudes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99fd66d108327bd7220db2025c513